### PR TITLE
Workaround lack of namespace axis support in Firefox

### DIFF
--- a/wadl.xsl
+++ b/wadl.xsl
@@ -514,6 +514,10 @@ Mark Sawers <mark.sawers@ipc.com>
         <xsl:when test="$ns-uri and starts-with($ns-uri, 'http://www.w3.org/XML/') = false">
           <a href="{$ns-uri}#{$localname}"><xsl:value-of select="$localname"/></a>
         </xsl:when>
+        <xsl:when test="not($ns-uri) and ($prefix != '') and (count(ancestor::*/namespace::*) = 0)">
+          <!-- we're in Firefox without ns support -->
+          <a><xsl:value-of select="$localname"/></a>
+        </xsl:when>
         <xsl:when test="$qname">
           <span class="active_schema schema_of_{$qname} slideContainer">
             <a onclick="" class="schema_link">

--- a/xsd.xsl
+++ b/xsd.xsl
@@ -54,6 +54,10 @@
       <xsl:when test="$ns-uri and starts-with($ns-uri, 'http://www.w3.org/XML/') = false">
         <a target="_blank" href="{$ns-uri}#{$localname}"><xsl:value-of select="$localname"/></a>
       </xsl:when>
+      <xsl:when test="not($ns-uri) and ($prefix != '') and (count(ancestor::*/namespace::*) = 0)">
+        <!-- we're in Firefox without ns support -->
+        <a><xsl:value-of select="$localname"/></a>
+      </xsl:when>
       <xsl:when test="$qname">
         <span class="active_schema schema_of_{$qname} slideContainer">
           <a onclick="" class="schema_link">


### PR DESCRIPTION
See Firefox bug [#94270](https://bugzilla.mozilla.org/show_bug.cgi?id=94270)
for details, I based the workaround on the code provided in
[comment #28](https://bugzilla.mozilla.org/show_bug.cgi?id=94270#c28).

Basically because Firefox lacks support for `namespace:` axis,
`$ns-uri` in `getHyperlinkedElement` ends up being null even for
elements that have namespace (e.g. `xs:int`).  This causes the
`xsl:choose` element to fall back to `when test="$qname"` and the
elements are displayed as e.g. 'xs:int' as schema_link that does
nothing.

This adds a check to see if there are no namespace elements but the
element has a prefix, in which case it will just display it as plain
local name, e.g. `int`.  Still using an <a> tag for it to keep it in
the same style as non-namespaced elements.
