### PR TITLE
Fix weird issues with schema links in chrome

### DIFF
--- a/wadl.xsl
+++ b/wadl.xsl
@@ -511,7 +511,7 @@ Mark Sawers <mark.sawers@ipc.com>
         <xsl:when test="$ns-uri='http://www.w3.org/2001/XMLSchema' or $ns-uri='http://www.w3.org/2001/XMLSchema-instance'">
           <a href="http://www.w3.org/TR/xmlschema-2/#{$localname}"><xsl:value-of select="$localname"/></a>
         </xsl:when>
-        <xsl:when test="$ns-uri and starts-with($ns-uri, 'http://www.w3.org/XML/') = false">
+        <xsl:when test="not(normalize-space($ns-uri) = '') and starts-with($ns-uri, 'http://www.w3.org/XML/') = false">
           <a href="{$ns-uri}#{$localname}"><xsl:value-of select="$localname"/></a>
         </xsl:when>
         <xsl:when test="not($ns-uri) and ($prefix != '') and (count(ancestor::*/namespace::*) = 0)">

--- a/xsd.xsl
+++ b/xsd.xsl
@@ -51,7 +51,7 @@
       <xsl:when test="$ns-uri='http://www.w3.org/2001/XMLSchema' or $ns-uri='http://www.w3.org/2001/XMLSchema-instance'">
         <a target="_blank" href="http://www.w3.org/TR/xmlschema-2/#{$localname}"><xsl:value-of select="$localname"/></a>
       </xsl:when>
-      <xsl:when test="$ns-uri and starts-with($ns-uri, 'http://www.w3.org/XML/') = false">
+      <xsl:when test="not(normalize-space($ns-uri) = '') and starts-with($ns-uri, 'http://www.w3.org/XML/') = false">
         <a target="_blank" href="{$ns-uri}#{$localname}"><xsl:value-of select="$localname"/></a>
       </xsl:when>
       <xsl:when test="not($ns-uri) and ($prefix != '') and (count(ancestor::*/namespace::*) = 0)">


### PR DESCRIPTION
Fix issue where a link to schema for complex elements may not be
generated correctly (in chrome).

Turns out `boolean($ns-uri)` is actually true when `$ns-uri = ''`
in many XSLT engines including the one used in chrome (it is false in
FF) (as used in test:

```
$ns-uri and starts-with($ns-uri, 'http://www.w3.org/XML/') = false
```

inside the `getHyperlinkedElement` template).

This fixes the problem by changing this test to:

```
not(normalize-space($ns-uri) = '') and starts-with($ns-uri, 'http://www.w3.org/XML/') = false
```

which is safer and seems to work consistently across browsers (at least
FF and Chrome).
